### PR TITLE
Add accountable role sections across policies

### DIFF
--- a/policies/cyber-security/access-control-policy.md
+++ b/policies/cyber-security/access-control-policy.md
@@ -67,6 +67,15 @@ This policy applies to all employees, contractors, consultants, partners, and te
 - **Internal Audit:** Performs independent assessments of access control effectiveness and reports findings to management.
 - **Users:** Maintain the confidentiality of their credentials, follow approved procedures, and report suspected account misuse.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Monitoring and Enforcement
 
 - All access to critical systems must be logged and retained according to the company’s data retention schedule.

--- a/policies/cyber-security/api-security-policy.md
+++ b/policies/cyber-security/api-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor api security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/backup-and-data-retention-policy.md
+++ b/policies/cyber-security/backup-and-data-retention-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor backup and data retention controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/business-continuity-plan.md
+++ b/policies/cyber-security/business-continuity-plan.md
@@ -61,6 +61,15 @@ This plan applies to all departments, business units, and supporting services th
 - **IT Disaster Recovery Team:** Manages restoration of technology services, including systems, networks, and data.
 - **Employees:** Follow instructions during activation, report issues, and maintain awareness of their role in continuity procedures.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Training and Awareness
 
 - All employees shall receive BCP awareness training during onboarding and annually thereafter.

--- a/policies/cyber-security/cloud-security-policy.md
+++ b/policies/cyber-security/cloud-security-policy.md
@@ -50,6 +50,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor cloud security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/cloud-service-provider-security-assessment-policy.md
+++ b/policies/cyber-security/cloud-service-provider-security-assessment-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor cloud service provider security assessment controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/cryptography-and-key-management-policy.md
+++ b/policies/cyber-security/cryptography-and-key-management-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor cryptography and key management controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/data-encryption-policy.md
+++ b/policies/cyber-security/data-encryption-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor data encryption controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/data-protection-and-privacy-policy.md
+++ b/policies/cyber-security/data-protection-and-privacy-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor data protection and privacy controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/disaster-recovery-policy.md
+++ b/policies/cyber-security/disaster-recovery-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor disaster recovery controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/endpoint-security-and-malware-protection-policy.md
+++ b/policies/cyber-security/endpoint-security-and-malware-protection-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor endpoint security and malware protection controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/firewall-and-network-security-policy.md
+++ b/policies/cyber-security/firewall-and-network-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor firewall and network security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/forensics-and-evidence-handling-policy.md
+++ b/policies/cyber-security/forensics-and-evidence-handling-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor forensics and evidence handling controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/incident-response-plan.md
+++ b/policies/cyber-security/incident-response-plan.md
@@ -59,6 +59,15 @@ This plan applies to all information assets, personnel, facilities, and third pa
 - **Communications/Public Relations:** Handles public statements and media inquiries in coordination with management.
 - **All Employees:** Report suspected incidents promptly and cooperate with investigators.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Communication and Reporting
 
 - Incidents must be reported via the service desk or designated hotline within one hour of discovery.

--- a/policies/cyber-security/incident-response-policy.md
+++ b/policies/cyber-security/incident-response-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor incident response controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/logging-and-monitoring-policy.md
+++ b/policies/cyber-security/logging-and-monitoring-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor logging and monitoring controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/microsoft-365-security-policy.md
+++ b/policies/cyber-security/microsoft-365-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all Microsoft 365 services, accounts, and devices used to
 - **Management:** Provide resources to implement and maintain required Microsoft 365 controls.
 - **Security and Compliance Teams:** Configure, monitor, and improve Microsoft 365 security settings and respond to incidents.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to comply with this policy may result in disciplinary action and could expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/mobile-device-management-mdm-policy.md
+++ b/policies/cyber-security/mobile-device-management-mdm-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor mobile device management (mdm) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/monitoring-and-threat-intelligence-policy.md
+++ b/policies/cyber-security/monitoring-and-threat-intelligence-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor monitoring and threat intelligence controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/multi-factor-authentication-mfa-policy.md
+++ b/policies/cyber-security/multi-factor-authentication-mfa-policy.md
@@ -51,6 +51,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor multi-factor authentication (mfa) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/network-security-policy.md
+++ b/policies/cyber-security/network-security-policy.md
@@ -81,6 +81,15 @@ This policy applies to all corporate networks, including wired, wireless, virtua
 - **IT Operations:** Supports deployment of network infrastructure and ensures backups of device configurations.
 - **Employees and Contractors:** Use corporate networks only for authorized purposes and report suspected security issues.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Training and Awareness
 
 - Administrators must receive ongoing training on secure network design and emerging threats.

--- a/policies/cyber-security/ot-ics-security-policy.md
+++ b/policies/cyber-security/ot-ics-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor ot/ics security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/password-and-authentication-policy.md
+++ b/policies/cyber-security/password-and-authentication-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor password and authentication controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/passwordless-authentication-policy.md
+++ b/policies/cyber-security/passwordless-authentication-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor passwordless authentication controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/patch-and-vulnerability-management-policy.md
+++ b/policies/cyber-security/patch-and-vulnerability-management-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor patch and vulnerability management controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/physical-security-policy.md
+++ b/policies/cyber-security/physical-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor physical security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/remote-administration-policy.md
+++ b/policies/cyber-security/remote-administration-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor remote administration controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/remote-and-home-working-policy.md
+++ b/policies/cyber-security/remote-and-home-working-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor remote and home working controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/resilience-and-redundancy-policy.md
+++ b/policies/cyber-security/resilience-and-redundancy-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor resilience and redundancy controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/security-metrics-and-reporting-policy.md
+++ b/policies/cyber-security/security-metrics-and-reporting-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor security metrics and reporting controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/vulnerability-disclosure-and-reporting-policy.md
+++ b/policies/cyber-security/vulnerability-disclosure-and-reporting-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor vulnerability disclosure and reporting controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/vulnerability-management-policy.md
+++ b/policies/cyber-security/vulnerability-management-policy.md
@@ -85,6 +85,15 @@ This policy applies to all systems owned, leased, or operated by the organizatio
 - **Management:** Approves remediation timelines and exceptions, allocates resources, and enforces accountability.
 - **Third-Party Providers:** Address vulnerabilities in systems under their control and provide evidence of remediation upon request.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Metrics and Reporting
 
 - Monthly reports summarizing open vulnerabilities, remediation status, and overdue items are provided to management.

--- a/policies/cyber-security/web-application-security-policy.md
+++ b/policies/cyber-security/web-application-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor web application security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/wireless-security-policy.md
+++ b/policies/cyber-security/wireless-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor wireless security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/cyber-security/zero-trust-security-policy.md
+++ b/policies/cyber-security/zero-trust-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor zero trust security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/hr/code-of-conduct.md
+++ b/policies/hr/code-of-conduct.md
@@ -58,6 +58,15 @@ This Code applies to every employee, director, agency worker, consultant, and co
 - **Human Resources:** Maintain this Code, provide guidance and ensure disciplinary processes are followed.
 - **Information Security Manager:** Monitor compliance with security-related obligations and advise on protective measures.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Reporting
 Employees must report suspected violations or unethical behaviour to management, Human Resources or the confidential reporting channel without fear of retaliation. Anonymous reports will be accepted where legally permissible.
 

--- a/policies/hr/disciplinary-policy-for-security-breaches.md
+++ b/policies/hr/disciplinary-policy-for-security-breaches.md
@@ -32,6 +32,15 @@ Applies to all employees, contractors and third parties who access Cyber Ask Ltd
 - **Information Security Manager:** Lead technical investigations, maintain evidence and advise on corrective controls.
 - **Human Resources:** Oversee disciplinary procedures, maintain records and ensure fairness and compliance with employment law.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to comply with this policy may result in disciplinary action up to and including dismissal, civil recovery and criminal prosecution.
 

--- a/policies/hr/employee-handbook.md
+++ b/policies/hr/employee-handbook.md
@@ -71,6 +71,15 @@ Applies to every employee, worker, intern and contractor engaged by Cyber Ask Lt
 - **Managers:** Communicate expectations, monitor compliance and support staff development.
 - **Human Resources:** Maintain policies, provide advice and ensure legal compliance.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Review and Acknowledgment
 Employees must acknowledge receipt of this handbook on joining and whenever revised. The handbook will be reviewed annually to ensure alignment with legislation and best practice.
 

--- a/policies/hr/employee-onboarding-and-offboarding-policy.md
+++ b/policies/hr/employee-onboarding-and-offboarding-policy.md
@@ -39,6 +39,15 @@ Applies to all employees, contractors and third parties who join or leave Cyber 
 - **IT Department:** Provision and revoke technical access, maintain asset inventory and log changes.
 - **Facilities:** Manage physical access cards and office equipment.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to follow this policy may lead to disciplinary action and increased security risk. Regular audits shall verify adherence to ISO/IEC 27001 control A.7.1 and NCSC CAF principles.
 

--- a/policies/hr/equality-diversity-and-inclusion-policy.md
+++ b/policies/hr/equality-diversity-and-inclusion-policy.md
@@ -24,6 +24,15 @@ Applies to all employees, contractors, applicants and visitors of Cyber Ask Ltd.
 - **Managers:** Lead inclusive teams, challenge inappropriate behaviour and support reasonable adjustments.
 - **HR:** Monitor diversity metrics, provide guidance and ensure compliance with legislation.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Breaches of this policy may result in disciplinary action. The policy supports ISO/IEC 27001 control A.7.1 and NCSC CAF culture objectives.
 

--- a/policies/hr/grievance-policy.md
+++ b/policies/hr/grievance-policy.md
@@ -24,6 +24,15 @@ Applies to all employees of Cyber Ask Ltd. Contractors may use contractual dispu
 - **Managers:** Seek informal resolution where possible and cooperate with investigations.
 - **HR:** Administer the grievance procedure, maintain records and ensure compliance with legislation.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to follow this policy may result in unresolved disputes and potential legal claims. This policy aligns with ISO/IEC 27001 control A.7.1.2 and supports a culture of openness as required by the NCSC CAF.
 

--- a/policies/hr/health-and-safety-in-it-operations-policy.md
+++ b/policies/hr/health-and-safety-in-it-operations-policy.md
@@ -29,6 +29,15 @@ Applies to all employees, contractors and visitors who access IT facilities or u
 - **Employees and Contractors:** Follow safety procedures, complete assessments and report hazards or incidents.
 - **Facilities Team:** Maintain physical infrastructure, fire safety systems and environmental controls.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to comply may result in disciplinary action and could lead to prosecution under health and safety legislation. Compliance with ISO/IEC 27001 control A.6 and NCSC CAF managing security risk objective is required.
 

--- a/policies/hr/leave-policy.md
+++ b/policies/hr/leave-policy.md
@@ -46,6 +46,15 @@ Applies to all employees of Cyber Ask Ltd; contractors may have separate contrac
 - **Managers:** Plan resources, approve leave fairly and conduct return-to-work interviews.
 - **Human Resources:** Maintain records, advise on legislation and monitor compliance.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Review
 This policy will be reviewed annually or following changes in employment law.
 

--- a/policies/hr/onboarding-policy.md
+++ b/policies/hr/onboarding-policy.md
@@ -45,6 +45,15 @@ Covers all permanent, fixed-term and temporary personnel joining the organisatio
 - **IT:** Provision equipment and access, maintain inventory and assist with technical setup.
 - **New Starter:** Complete required training, review policies and seek clarification when unsure.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Review
 This policy will be reviewed annually and updated to reflect changes in legislation, security standards and organisational requirements.
 

--- a/policies/hr/social-media-and-external-communications-policy.md
+++ b/policies/hr/social-media-and-external-communications-policy.md
@@ -43,6 +43,15 @@ Applies to all employees, contractors and representatives using social media or 
 - **Information Security Manager:** Ensure secure configuration and monitoring of accounts and tools.
 - **HR:** Enforce policy breaches and maintain training records.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Non-compliance may result in removal of access, disciplinary action or legal proceedings. This policy supports ISO/IEC 27001 controls A.13.2 and NCSC CAF objective A: Managing Security Risk.
 

--- a/policies/hr/training-and-awareness-policy.md
+++ b/policies/hr/training-and-awareness-policy.md
@@ -27,6 +27,15 @@ Applies to employees, contractors and third parties who require access to compan
 - **Employees and Contractors:** Complete required training by specified deadlines and apply learning in their duties.
 - **Information Security Manager:** Provide subject matter expertise and verify effectiveness of security training.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to complete mandatory training may lead to disciplinary action or removal of system access. This policy aligns with ISO/IEC 27001 control A.7.2.2 and NCSC CAF objective C: Cyber Defence.
 

--- a/policies/hr/whistleblowing-and-ethical-reporting-policy.md
+++ b/policies/hr/whistleblowing-and-ethical-reporting-policy.md
@@ -27,6 +27,15 @@ Covers all employees, contractors, suppliers and stakeholders who wish to report
 - **Employees and Contractors:** Report suspected misconduct promptly and cooperate with investigations.
 - **HR and Legal:** Provide guidance on employment and legal implications.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (HR Director):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Reviews people-related security risks and approves exceptions impacting information assets in line with the Information Security Policy.
+- **Risk and Compliance Committee:** Evaluates residual workforce risks and endorses major decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Approves strategic or resource-intensive changes in accordance with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to adhere to this policy may result in disciplinary action. This policy supports ISO/IEC 27001 control A.16.1 and NCSC CAF response and recovery objectives.
 

--- a/policies/information-security/acceptable-use-policy.md
+++ b/policies/information-security/acceptable-use-policy.md
@@ -51,6 +51,16 @@ Applies to all employees, contractors, and third parties using company equipment
 - Use of company systems may be monitored and logged for operational, compliance and security purposes. Users have no expectation of privacy when utilising company resources.
 - Failure to comply with this policy may result in disciplinary action up to and including dismissal, and could lead to civil or criminal penalties.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Monitoring
 
 Company systems may be monitored to ensure compliance and security.

--- a/policies/information-security/account-separation-policy.md
+++ b/policies/information-security/account-separation-policy.md
@@ -40,6 +40,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor account separation controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/ai-and-emerging-technology-security-policy.md
+++ b/policies/information-security/ai-and-emerging-technology-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor ai and emerging technology security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/asset-management-policy.md
+++ b/policies/information-security/asset-management-policy.md
@@ -22,6 +22,16 @@ This policy outlines requirements for inventorying and protecting information as
 
 - Assets leaving company control must be approved by management and have data securely erased or destroyed.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Review
 
 This policy is reviewed annually by the Information Security Officer.

--- a/policies/information-security/bring-your-own-device-byod-policy.md
+++ b/policies/information-security/bring-your-own-device-byod-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor bring your own device (byod) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/business-continuity-management-bcm-policy.md
+++ b/policies/information-security/business-continuity-management-bcm-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor business continuity management (bcm) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/change-management-policy.md
+++ b/policies/information-security/change-management-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor change management controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/continuous-improvement-policy.md
+++ b/policies/information-security/continuous-improvement-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor continuous improvement controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/corrective-and-preventive-action-capa-policy.md
+++ b/policies/information-security/corrective-and-preventive-action-capa-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor corrective and preventive action (capa) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/cyber-governance-policy.md
+++ b/policies/information-security/cyber-governance-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor cyber governance controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/data-classification-and-handling-policy.md
+++ b/policies/information-security/data-classification-and-handling-policy.md
@@ -44,6 +44,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor data classification and handling controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/data-classification-policy.md
+++ b/policies/information-security/data-classification-policy.md
@@ -25,6 +25,15 @@ This policy establishes a framework for classifying and handling information bas
 - **Users:** Follow handling requirements and report misclassification.
 - **IT:** Provide technical controls to enforce classifications.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Review
 
 Classifications are reviewed annually or when significant changes in data usage occur.

--- a/policies/information-security/data-integrity-and-quality-policy.md
+++ b/policies/information-security/data-integrity-and-quality-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor data integrity and quality controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/data-loss-prevention-dlp-policy.md
+++ b/policies/information-security/data-loss-prevention-dlp-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor data loss prevention (dlp) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/document-control-policy.md
+++ b/policies/information-security/document-control-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor document control controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/encryption-policy.md
+++ b/policies/information-security/encryption-policy.md
@@ -44,6 +44,15 @@ All systems, applications, and devices that store or transmit company data.
 - **System Owners:** Implement encryption according to this policy.
 - **Users:** Protect passwords and report potential compromises.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Review
 
 This policy is reviewed annually or when new cryptographic standards emerge.

--- a/policies/information-security/end-of-life-and-unsupported-software-policy.md
+++ b/policies/information-security/end-of-life-and-unsupported-software-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor end-of-life and unsupported software controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/environmental-security-policy.md
+++ b/policies/information-security/environmental-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor environmental security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/information-security-policy.md
+++ b/policies/information-security/information-security-policy.md
@@ -55,6 +55,16 @@ Applies to all employees, contractors, and third parties who access company info
 - Implement controls based on the Statement of Applicability and risk treatment plan.
 - Monitor risks and update assessments after major changes or incidents.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Compliance
 
 - All legal, regulatory, and contractual obligations must be identified and met.

--- a/policies/information-security/internal-audit-policy.md
+++ b/policies/information-security/internal-audit-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor internal audit controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/media-handling-and-equipment-disposal-policy.md
+++ b/policies/information-security/media-handling-and-equipment-disposal-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor media handling and equipment disposal controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/privileged-access-management-pam-policy.md
+++ b/policies/information-security/privileged-access-management-pam-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor privileged access management (pam) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/risk-assessment-methodology.md
+++ b/policies/information-security/risk-assessment-methodology.md
@@ -24,6 +24,16 @@ This document describes the systematic approach for identifying, analyzing, and 
 
 The Information Security Officer approves the methodology and reviews it annually.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/information-security/risk-assessment-report.md
+++ b/policies/information-security/risk-assessment-report.md
@@ -24,6 +24,16 @@ This report summarizes the results of the latest information security risk asses
 
 Management reviews and approves this report and associated treatment decisions.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/information-security/risk-management-policy.md
+++ b/policies/information-security/risk-management-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor risk management controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/risk-treatment-plan.md
+++ b/policies/information-security/risk-treatment-plan.md
@@ -13,6 +13,16 @@ This plan documents actions to address identified information security risks, fu
 - **Target Date:** Expected completion date for treatment activities.
 - **Residual Risk:** Level of risk remaining after treatment and acceptance decision.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Monitoring
 
 Risk owners provide status updates monthly until treatments are complete.

--- a/policies/information-security/scope-of-isms.md
+++ b/policies/information-security/scope-of-isms.md
@@ -23,6 +23,16 @@ This document defines the boundaries and applicability of the Information Securi
 
 Senior management approves this scope statement and reviews it annually or when significant organizational changes occur.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/information-security/secure-configuration-policy.md
+++ b/policies/information-security/secure-configuration-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor secure configuration controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/security-objectives.md
+++ b/policies/information-security/security-objectives.md
@@ -12,6 +12,16 @@ This document establishes measurable objectives to guide the Information Securit
 - Remediate critical vulnerabilities within 14 days of discovery.
 - Achieve zero successful phishing attacks through simulated testing each quarter.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Monitoring and Review
 
 The Information Security Officer tracks progress and reports results to management quarterly. Objectives are reviewed annually and updated as business needs evolve.

--- a/policies/information-security/security-operations-policy.md
+++ b/policies/information-security/security-operations-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor security operations controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/software-development-security-policy.md
+++ b/policies/information-security/software-development-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor software development security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/statement-of-applicability.md
+++ b/policies/information-security/statement-of-applicability.md
@@ -17,6 +17,16 @@ The Statement of Applicability (SoA) lists ISO 27001 Annex A controls and their 
 - Updated whenever new controls are implemented or risks change.
 - Reviewed and approved by management annually.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/information-security/supplier-security-policy.md
+++ b/policies/information-security/supplier-security-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor supplier security controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/supply-chain-continuity-policy.md
+++ b/policies/information-security/supply-chain-continuity-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor supply chain continuity controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/information-security/testing-and-qa-policy.md
+++ b/policies/information-security/testing-and-qa-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor testing and qa controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (Information Security Manager):** Maintains this policy, coordinates updates, and ensures alignment with the Cyber Governance Policy and Document Control Policy.
+- **Chief Information Security Officer (CISO):** Approves exceptions, risk acceptances, and material control changes in line with the Information Security Policy and Risk Management Policy.
+- **Risk and Compliance Committee:** Reviews escalated risks, endorses significant remediation decisions, and provides oversight consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies budgetary or strategic decisions related to this policy as defined in the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/confidentiality-agreement.md
+++ b/policies/legal/confidentiality-agreement.md
@@ -29,6 +29,16 @@ This agreement governs the protection of confidential information exchanged betw
 
 This agreement is governed by the laws of the jurisdiction specified in the associated contract.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/legal/customer-feedback-and-complaint-handling-policy.md
+++ b/policies/legal/customer-feedback-and-complaint-handling-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor customer feedback and complaint handling controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/cyber-insurance-compliance-policy.md
+++ b/policies/legal/cyber-insurance-compliance-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor cyber insurance compliance controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/export-control-and-sanctions-compliance-policy.md
+++ b/policies/legal/export-control-and-sanctions-compliance-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor export control and sanctions compliance controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/insurance-and-cyber-liability-policy.md
+++ b/policies/legal/insurance-and-cyber-liability-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor insurance and cyber liability controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/intellectual-property-protection-policy.md
+++ b/policies/legal/intellectual-property-protection-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor intellectual property protection controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/nda-template.md
+++ b/policies/legal/nda-template.md
@@ -23,6 +23,16 @@ This template provides standard terms for establishing confidentiality obligatio
 
 The NDA is effective when signed by authorized representatives of both parties.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
+
 ## Implementation Guidelines
 - All requests and approvals must be tracked in the ServiceDesk system.
 - Data at rest must use AES-256 encryption; data in transit must use TLS 1.2+ with perfect forward secrecy.

--- a/policies/legal/outsourcing-and-managed-service-provider-msp-policy.md
+++ b/policies/legal/outsourcing-and-managed-service-provider-msp-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor outsourcing and managed service provider (msp) controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/outsourcing-governance-policy.md
+++ b/policies/legal/outsourcing-governance-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor outsourcing governance controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/pci-dss-policy.md
+++ b/policies/legal/pci-dss-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor pci dss controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/records-management-and-archiving-policy.md
+++ b/policies/legal/records-management-and-archiving-policy.md
@@ -43,6 +43,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor records management and archiving controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/records-of-processing-policy.md
+++ b/policies/legal/records-of-processing-policy.md
@@ -47,6 +47,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor records of processing controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.

--- a/policies/legal/regulatory-and-legal-compliance-policy.md
+++ b/policies/legal/regulatory-and-legal-compliance-policy.md
@@ -36,6 +36,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor regulatory and legal compliance controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.
 

--- a/policies/legal/third-party-access-control-policy.md
+++ b/policies/legal/third-party-access-control-policy.md
@@ -43,6 +43,15 @@ This policy applies to all employees, contractors, and third parties who access 
 - **Management:** Provide resources and enforce this policy within their areas of responsibility.
 - **Security and Compliance Teams:** Monitor third-party access control controls, provide guidance, and coordinate improvements.
 
+## Accountable Roles and Decision Authority
+
+- **Policy Owner (General Counsel):** Maintains this policy, coordinates updates, and ensures alignment with the Document Control Policy and Cyber Governance Policy.
+- **Chief Information Security Officer (CISO):** Validates security implications and approves exceptions affecting information assets per the Information Security Policy.
+- **Risk and Compliance Committee:** Oversees regulatory risk treatment decisions consistent with the Risk Management Policy.
+- **Executive Leadership Team:** Ratifies significant legal or contractual commitments in line with the Cyber Governance Policy.
+
+Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
+
 ## Compliance
 Failure to adhere to this policy may result in disciplinary action, up to and including termination, and may expose the organization to legal or regulatory penalties.
 


### PR DESCRIPTION
## Summary
- add a standardized "Accountable Roles and Decision Authority" section across cybersecurity and information security policies with clear approval paths linked to central governance documents
- document accountable roles and decision authorities for HR and legal policies, ensuring exceptions and escalations align with existing governance references

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cb06d94ce48324b6e9010652661192