### PR TITLE
Add approval and communication requirements to HR policies

### DIFF
--- a/policies/hr/code-of-conduct.md
+++ b/policies/hr/code-of-conduct.md
@@ -69,6 +69,11 @@ This Code applies to every employee, director, agency worker, consultant, and co
 
 Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
 
+## Approval and Communication
+- The Board of Directors and Chief Executive Officer approve this Code of Conduct and any material revisions before they take effect.
+- Following approval, the Executive Leadership Team and HR Director distribute the current version to all personnel via email, the intranet, and formal briefings.
+- Employees must sign an acknowledgement within 10 working days of publication; completed acknowledgements are stored with individual HR records in the secure HR information system.
+
 ## Reporting
 Employees must report suspected violations or unethical behaviour to management, Human Resources or the confidential reporting channel without fear of retaliation. Anonymous reports will be accepted where legally permissible.
 

--- a/policies/hr/employee-handbook.md
+++ b/policies/hr/employee-handbook.md
@@ -80,6 +80,11 @@ Applies to every employee, worker, intern and contractor engaged by Cyber Ask Lt
 
 Exception requests must follow the exception management process described in the Cyber Governance Policy and all approvals must be recorded in accordance with the Document Control Policy.
 
+## Approval and Communication
+- The Board of Directors and Chief Executive Officer review and approve this handbook and any material updates before issue.
+- Once approved, the Executive Leadership Team and HR Director communicate the current version to all personnel via email, the intranet, and onboarding briefings.
+- Employees must sign an acknowledgement within 10 working days of receipt; signed acknowledgements are filed with individual HR records in the secure HR information system.
+
 ## Review and Acknowledgment
 Employees must acknowledge receipt of this handbook on joining and whenever revised. The handbook will be reviewed annually to ensure alignment with legislation and best practice.
 


### PR DESCRIPTION
## Summary
- add Approval and Communication section to the Employee Handbook describing board sign-off, executive distribution, and acknowledgement storage
- add matching Approval and Communication section to the Code of Conduct covering executive approvals, staff communication, and HR record retention

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68cb06e1e4608324bebb22e521a9c01a