### PR TITLE
Add comprehensive governance and security templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@ A Markdown-based company policy and document set.
 
 This repository contains placeholder policies for HR, cyber security, information security, and legal NDAs. Each document is drafted to support CE/CE+ and ISO 27001 compliance.
 
-Explore the `policies/` directory for individual templates.
+- Explore the `policies/` directory for detailed policies and guidance.
+- Visit the `templates/` directory for ready-to-use forms covering DPIAs, records of processing, asset inventories, risk assessments, NDAs, contracts, and security incident documentation.
+
+> Duplicate a template before editing so the originals remain reusable for future engagements.

--- a/policies/legal/nda-template.md
+++ b/policies/legal/nda-template.md
@@ -5,6 +5,8 @@
 
 This template provides standard terms for establishing confidentiality obligations with partners, vendors, or prospective clients.
 
+> For a fillable short-form NDA, use [templates/nda-template.md](../../templates/nda-template.md).
+
 ## Parties
 
 - **Disclosing Party:** Company sharing confidential information.

--- a/policies/policy-index.md
+++ b/policies/policy-index.md
@@ -102,3 +102,13 @@
 - [Regulatory and Legal Compliance Policy](policies/legal/regulatory-and-legal-compliance-policy.md) – This policy establishes requirements for regulatory and legal compliance to protect organizational assets and ensure compliance with applicable laws and regulations.
 - [Third-Party Access Control Policy](policies/legal/third-party-access-control-policy.md) – This policy establishes requirements for third-party access control to protect organizational assets and ensure compliance with applicable laws and regulations.
 
+
+## Templates
+- [Data Protection Impact Assessment (DPIA) Template](../templates/dpia-template.md) – Capture privacy risks, mitigations, and approvals for high-risk processing activities.
+- [Records of Processing Activities Template](../templates/records-of-processing-template.md) – Maintain a GDPR-compliant register of processing purposes, data categories, and retention.
+- [Asset Register Template](../templates/asset-register-template.md) – Inventory information assets, owners, classifications, and lifecycle events.
+- [Risk Assessment Template](../templates/risk-assessment-template.md) – Document threats, scoring, treatment decisions, and review checkpoints.
+- [Non-Disclosure Agreement Template](../templates/nda-template.md) – Generate a short-form bilateral confidentiality agreement with fillable placeholders.
+- [Master Services Contract Template](../templates/contract-template.md) – Structure commercial engagements with scopes, fees, and legal protections.
+- [Security Incident Log Template](../templates/security-incident-log-template.md) – Record real-time response activities, communications, and decisions during an incident.
+- [Security Incident Report Template](../templates/security-incident-report-template.md) – Summarise incident impact, response actions, lessons learned, and approvals after closure.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,16 @@
+# Template Library
+
+This directory provides fillable templates that support Cyber Ask Ltd's governance, risk, compliance, and legal workflows. Each template is designed to be duplicated and completed for a specific engagement, project, or incident record.
+
+## Available Templates
+
+- [Data Protection Impact Assessment (DPIA)](dpia-template.md)
+- [Records of Processing Activities (RoPA)](records-of-processing-template.md)
+- [Asset Register](asset-register-template.md)
+- [Risk Assessment](risk-assessment-template.md)
+- [Non-Disclosure Agreement (NDA)](nda-template.md)
+- [Master Services Contract](contract-template.md)
+- [Security Incident Log](security-incident-log-template.md)
+- [Security Incident Report](security-incident-report-template.md)
+
+> **Usage tip:** Save a copy of the relevant template, complete all required sections, and store the finalized document in the appropriate record repository (e.g., SharePoint site, GRC tool, contract management system).

--- a/templates/asset-register-template.md
+++ b/templates/asset-register-template.md
@@ -1,0 +1,19 @@
+# Asset Register Template
+
+Use this register to maintain an inventory of information assets, infrastructure components, and critical services. Align asset classifications with the Information Security Policy.
+
+| Asset ID | Asset Name / Description | Asset Type (Hardware / Software / Data / Service) | Owner | Custodian / Support Team | Information Classification | Location / Hosting | Business Criticality | Dependencies | Backup / Recovery Details | Last Review Date |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+
+## Asset Lifecycle Notes
+
+| Asset ID | Event (Acquisition / Update / Decommission) | Description | Date | Authorised By |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+> **Reminder:** Link this register to configuration management databases (CMDBs) and update risk assessments when asset criticality changes.

--- a/templates/contract-template.md
+++ b/templates/contract-template.md
@@ -1,0 +1,119 @@
+# Master Services Contract Template
+
+Use this modular contract template for new customer or supplier engagements. Tailor clauses to reflect the services, pricing, and regulatory obligations for the engagement.
+
+## 1. Agreement Details
+
+| Item | Details |
+| --- | --- |
+| Agreement Title | |
+| Effective Date | |
+| Customer Legal Name | |
+| Supplier Legal Name | |
+| Contract Owner (Internal) | |
+| Version / Revision | |
+
+## 2. Recitals
+
+- **[Customer Name]** requires **[describe services/products]**.
+- **[Supplier Name]** agrees to provide the services/products according to this Agreement.
+
+## 3. Definitions
+
+Define key terms used throughout the Agreement, e.g., "Deliverables", "Services", "Service Levels", "Confidential Information", "Data Protection Laws".
+
+## 4. Scope of Services
+
+- Description of services or deliverables
+- Service levels and performance metrics
+- Acceptance criteria and testing requirements
+- Change control process
+
+## 5. Term and Renewal
+
+- Initial term (e.g., 12 months from Effective Date)
+- Renewal options (automatic vs. manual)
+- Notice periods for termination or non-renewal
+
+## 6. Fees and Payment
+
+| Fee Component | Amount / Rate | Billing Frequency | Payment Terms | Notes |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+- Invoicing process and contacts
+- Expenses and reimbursement policy
+
+## 7. Confidentiality and Data Protection
+
+- Reference NDA obligations or include confidentiality clause
+- Data protection obligations (compliance with GDPR/UK GDPR)
+- Data processing addendum reference (if applicable)
+- Security requirements (link to Information Security Policy or Supplier Security Policy)
+
+## 8. Intellectual Property
+
+- Ownership of pre-existing IP
+- Ownership of newly developed materials
+- Licensing terms and restrictions
+
+## 9. Warranties and Representations
+
+- Supplier warranties (skills, lawful authority, compliance with laws)
+- Customer warranties (authority to enter into agreement)
+
+## 10. Liability and Indemnities
+
+- Limitations of liability (cap, exclusions)
+- Mutual indemnities (e.g., IP infringement, data protection breaches)
+- Insurance requirements
+
+## 11. Termination
+
+- Termination for convenience
+- Termination for breach (cure periods)
+- Insolvency events
+- Consequences of termination (final payments, return of materials)
+
+## 12. Governance and Reporting
+
+| Meeting | Frequency | Participants | Agenda / Outputs |
+| --- | --- | --- | --- |
+|  |  |  |  |
+|  |  |  |  |
+
+- Key contacts and escalation paths
+- Reporting obligations (KPIs, compliance reports)
+
+## 13. Compliance and Regulatory Requirements
+
+- Anti-bribery and corruption compliance
+- Modern slavery, tax compliance, sanctions adherence
+- Industry-specific regulations (e.g., PCI DSS, ISO 27001)
+
+## 14. General Provisions
+
+- Assignment and subcontracting
+- Force majeure
+- Notices (addresses and method)
+- Entire agreement and variation
+- Governing law and jurisdiction
+
+## 15. Schedules and Appendices
+
+List supporting schedules such as:
+
+1. **Schedule 1 – Statement of Work / Deliverables**
+2. **Schedule 2 – Service Level Agreement**
+3. **Schedule 3 – Data Processing Addendum**
+4. **Schedule 4 – Pricing Schedule**
+
+## 16. Signatures
+
+| Party | Name | Title | Signature | Date |
+| --- | --- | --- | --- | --- |
+| [Customer Legal Name] |  |  |  |  |
+| [Supplier Legal Name] |  |  |  |  |
+
+> **Reminder:** Store the executed contract and related schedules in the contract repository and link to relevant risk, supplier, and security records.

--- a/templates/dpia-template.md
+++ b/templates/dpia-template.md
@@ -1,0 +1,79 @@
+# Data Protection Impact Assessment (DPIA) Template
+
+Duplicate this file and complete all sections for each processing activity that may present a high risk to the rights and freedoms of individuals. Keep the completed DPIA with your Records of Processing Activities and update it whenever material changes occur.
+
+## 1. DPIA Overview
+
+| Item | Details |
+| --- | --- |
+| Project / Processing Name | |
+| Business Owner | |
+| Data Protection Officer (Reviewer) | |
+| Date Initiated | |
+| Date Completed | |
+| Related Systems / Services | |
+| Linked Change / Project Reference | |
+
+## 2. Description of Processing
+
+- **Purpose of Processing:** 
+- **Scope of Data Subjects:** 
+- **Categories of Personal Data:** 
+- **Processing Activities (collection, storage, sharing, disposal):** 
+- **Frequency and Volume of Processing:** 
+- **International Data Transfers (locations, safeguards):** 
+
+## 3. Consultation and Stakeholders
+
+| Stakeholder | Role / Interest | Consultation Outcome |
+| --- | --- | --- |
+|  |  |  |
+|  |  |  |
+|  |  |  |
+
+- **Consultation with Data Subjects (if applicable):** 
+- **Consultation with Supervisory Authorities (if applicable):** 
+
+## 4. Necessity and Proportionality Assessment
+
+| Control Area | Considerations | Adequacy Assessment |
+| --- | --- | --- |
+| Lawful Basis | | |
+| Data Minimisation | | |
+| Storage Limitation | | |
+| Accuracy | | |
+| Transparency and Fair Processing Notices | | |
+| Data Subject Rights Enablement | | |
+| Processor / Third-Party Governance | | |
+| Technical and Organisational Measures | | |
+
+## 5. Risk Assessment
+
+| Risk ID | Threat Scenario | Impacted Rights / Freedoms | Likelihood (L) | Impact (I) | Inherent Risk (L x I) |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+
+## 6. Risk Mitigation Plan
+
+| Risk ID | Existing Controls | Additional Measures Required | Control Owner | Target Completion Date | Residual Risk |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+
+## 7. Approval and Sign-off
+
+| Name | Role | Signature / Approval | Date |
+| --- | --- | --- | --- |
+|  | Business Owner |  |  |
+|  | Data Protection Officer |  |  |
+|  | Chief Information Security Officer |  |  |
+
+## 8. Review Schedule
+
+- **Next Review Trigger (date / event):** 
+- **Archiving Instructions:** 
+
+> **Reminder:** Incorporate mitigation actions into the Risk Treatment Plan and track progress through the risk register or GRC platform.

--- a/templates/nda-template.md
+++ b/templates/nda-template.md
@@ -1,0 +1,67 @@
+# Non-Disclosure Agreement (NDA) Template
+
+This short-form NDA is intended for bilateral engagements with customers, suppliers, or partners. Replace bracketed text with specific details and obtain signatures from authorised representatives.
+
+## 1. Parties
+
+This Non-Disclosure Agreement ("Agreement") is made on **[Date]** between:
+
+- **[Disclosing Party Legal Name]**, with a registered address at **[Address]** ("Disclosing Party"); and
+- **[Receiving Party Legal Name]**, with a registered address at **[Address]** ("Receiving Party").
+
+Each a "Party" and together the "Parties".
+
+## 2. Purpose
+
+Confidential Information may be disclosed for the limited purpose of **[Describe purpose, e.g., evaluating a potential services engagement]** (the "Purpose").
+
+## 3. Definition of Confidential Information
+
+Confidential Information includes all information disclosed by either Party (whether oral, written, electronic, or other form) that is identified as confidential or would reasonably be considered confidential given the nature of the information and the circumstances of disclosure. Confidential Information does not include information that:
+
+1. is or becomes publicly available through no fault of the Receiving Party;
+2. was lawfully known to the Receiving Party prior to disclosure;
+3. is independently developed without use of the Confidential Information; or
+4. is lawfully received from a third party without restriction.
+
+## 4. Obligations of the Receiving Party
+
+The Receiving Party shall:
+
+- use Confidential Information solely for the Purpose;
+- restrict disclosure to employees, officers, or professional advisers who need to know the information for the Purpose and are bound by confidentiality obligations no less protective than those in this Agreement;
+- protect Confidential Information with at least the same degree of care used to safeguard its own confidential information (and no less than reasonable care);
+- promptly notify the Disclosing Party of any unauthorised disclosure or suspected breach; and
+- upon request, return or securely destroy all copies of Confidential Information.
+
+## 5. Term and Survival
+
+- This Agreement commences on the Effective Date and continues for **[Term, e.g., two (2) years]**.
+- The obligations of confidentiality survive for **[Survival Period, e.g., three (3) years]** following termination or expiry.
+
+## 6. Compelled Disclosure
+
+If the Receiving Party is legally required to disclose Confidential Information, it shall (where legally permissible) provide prompt written notice to the Disclosing Party and cooperate in seeking protective measures.
+
+## 7. Remedies
+
+The Receiving Party acknowledges that unauthorised disclosure may cause irreparable harm. The Disclosing Party is entitled to seek injunctive relief, specific performance, or other equitable remedies, in addition to any other rights or remedies available at law.
+
+## 8. Governing Law and Jurisdiction
+
+This Agreement is governed by the laws of **[Jurisdiction, e.g., England and Wales]** and the courts of **[Jurisdiction]** have exclusive jurisdiction over disputes arising from it.
+
+## 9. Miscellaneous
+
+- This Agreement constitutes the entire agreement regarding the subject matter and supersedes previous discussions.
+- Any amendments must be in writing and signed by both Parties.
+- Neither Party may assign this Agreement without the other Party's prior written consent, except to a successor in the event of merger or acquisition.
+
+## 10. Signatures
+
+| Party | Name | Title | Signature | Date |
+| --- | --- | --- | --- | --- |
+| [Disclosing Party Legal Name] |  |  |  |  |
+| [Receiving Party Legal Name] |  |  |  |  |
+
+> **Reminder:** File the executed NDA in the contract management repository and update the vendor/customer record accordingly.

--- a/templates/records-of-processing-template.md
+++ b/templates/records-of-processing-template.md
@@ -1,0 +1,19 @@
+# Records of Processing Activities (RoPA) Template
+
+Complete one entry per processing activity. Store the up-to-date register with legal/compliance records. Add or remove rows as needed.
+
+| Processing Reference | Business Owner | Purpose of Processing | Data Subjects | Categories of Personal Data | Special Category Data? (Y/N) | Lawful Basis | Processors / Recipients | Transfers Outside UK/EU (Safeguards) | Retention Period | Security Measures | Last Review Date |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |  |
+
+## Change Log
+
+| Date | Change Description | Updated By |
+| --- | --- | --- |
+|  |  |  |
+|  |  |  |
+
+> **Reminder:** When a processing activity changes, update the relevant DPIA, privacy notices, and contracts with processors.

--- a/templates/risk-assessment-template.md
+++ b/templates/risk-assessment-template.md
@@ -1,0 +1,61 @@
+# Risk Assessment Template
+
+Use this template to document new risk assessments or periodic reviews. Align scoring with the Risk Assessment Methodology and capture decisions in the Risk Treatment Plan.
+
+## 1. Context
+
+| Item | Details |
+| --- | --- |
+| Assessment Name | |
+| Business Function / Process | |
+| Assessment Trigger (project, change, review) | |
+| Prepared By | |
+| Date Initiated | |
+| Review Cycle | |
+
+## 2. Scope and Assumptions
+
+- **In-Scope Assets / Services:** 
+- **Excluded Items:** 
+- **Assumptions / Dependencies:** 
+
+## 3. Risk Matrix (define scoring reference)
+
+| Likelihood Score | Description |
+| --- | --- |
+| 1 | Rare – Exceptional circumstances only |
+| 2 | Unlikely – Could occur at some time |
+| 3 | Possible – Might occur at least annually |
+| 4 | Likely – Expected to occur multiple times per year |
+| 5 | Almost Certain – Expected to occur frequently |
+
+| Impact Score | Description |
+| --- | --- |
+| 1 | Negligible – Minimal impact, easily contained |
+| 2 | Minor – Limited operational disruption |
+| 3 | Moderate – Noticeable service impact or regulatory concern |
+| 4 | Major – Significant disruption, reportable breach likely |
+| 5 | Severe – Critical failure, substantial legal/financial penalties |
+
+## 4. Risk Register
+
+| Risk ID | Threat / Vulnerability Description | Impacted Assets / Processes | Existing Controls | Likelihood | Impact | Inherent Risk (L x I) | Additional Controls / Actions | Control Owner | Target Date | Residual Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+|  |  |  |  |  |  |  |  |  |  |  |
+
+## 5. Risk Acceptance and Treatment Decisions
+
+| Risk ID | Decision (Accept / Mitigate / Transfer / Avoid) | Decision Rationale | Approver | Approval Date |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+## 6. Review and Closure
+
+- **Follow-up Actions Tracked In:** 
+- **Next Scheduled Review:** 
+- **Additional Notes:** 
+
+> **Reminder:** Communicate high and critical risks to the Risk and Compliance Committee and ensure actions are reflected in the Corrective and Preventive Action (CAPA) log where applicable.

--- a/templates/security-incident-log-template.md
+++ b/templates/security-incident-log-template.md
@@ -1,0 +1,48 @@
+# Security Incident Log Template
+
+Use this log to capture real-time updates during an incident. Maintain one log per incident and ensure timestamps use UTC.
+
+## Incident Header
+
+| Item | Details |
+| --- | --- |
+| Incident ID | |
+| Incident Title | |
+| Severity | |
+| Date / Time Opened | |
+| Incident Commander | |
+| Reporting Source | |
+| Related Tickets / References | |
+
+## Activity Log
+
+| # | Date / Time (UTC) | Event Description | Action Taken | Owner | Next Steps |
+| --- | --- | --- | --- | --- | --- |
+| 1 |  |  |  |  |  |
+| 2 |  |  |  |  |  |
+| 3 |  |  |  |  |  |
+| 4 |  |  |  |  |  |
+| 5 |  |  |  |  |  |
+
+## Communications Log
+
+| Date / Time (UTC) | Audience | Message Summary | Author |
+| --- | --- | --- | --- |
+|  |  |  |  |
+|  |  |  |  |
+
+## Key Decisions
+
+| Date / Time (UTC) | Decision | Rationale | Approver |
+| --- | --- | --- | --- |
+|  |  |  |  |
+|  |  |  |  |
+
+## Outstanding Actions
+
+| Action | Owner | Due Date | Status |
+| --- | --- | --- | --- |
+|  |  |  |  |
+|  |  |  |  |
+
+> **Reminder:** Once the incident is closed, attach this log to the Security Incident Report and archive it according to the Incident Response Policy.

--- a/templates/security-incident-report-template.md
+++ b/templates/security-incident-report-template.md
@@ -1,0 +1,92 @@
+# Security Incident Report Template
+
+Complete this report after closing an incident. Attach supporting evidence (logs, screenshots, communications) and share with the Risk and Compliance Committee.
+
+## 1. Executive Summary
+
+- **Incident ID:** 
+- **Incident Title:** 
+- **Date / Time Detected:** 
+- **Date / Time Contained:** 
+- **Severity Level:** 
+- **Current Status:** (Closed / Monitoring / Lessons Learned Ongoing)
+- **High-Level Summary:** 
+
+## 2. Incident Details
+
+| Item | Details |
+| --- | --- |
+| Primary Systems / Services Impacted | |
+| Data Involved (classification, volume) | |
+| Affected Customers / Users | |
+| Incident Commander | |
+| Technical Lead | |
+| Communications Lead | |
+| Legal / Regulatory Liaison | |
+
+## 3. Timeline of Events
+
+| Date / Time (UTC) | Event Description | Source (Log / Ticket / Person) |
+| --- | --- | --- |
+|  |  |  |
+|  |  |  |
+|  |  |  |
+
+## 4. Root Cause Analysis
+
+- **Initial Cause:** 
+- **Contributing Factors:** 
+- **Root Cause Summary:** 
+- **Detection Method:** 
+
+## 5. Impact Assessment
+
+| Impact Area | Description | Severity |
+| --- | --- | --- |
+| Confidentiality |  |  |
+| Integrity |  |  |
+| Availability |  |  |
+| Regulatory / Legal |  |  |
+| Financial |  |  |
+| Reputational |  |  |
+
+## 6. Response Actions
+
+| Phase | Actions Taken | Owner | Completion Date |
+| --- | --- | --- | --- |
+| Identification |  |  |  |
+| Containment |  |  |  |
+| Eradication |  |  |  |
+| Recovery |  |  |  |
+| Communication |  |  |  |
+
+## 7. Notifications and Reporting
+
+| Stakeholder / Authority | Notification Required? (Y/N) | Date Sent | Reference / Ticket | Follow-up Actions |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+## 8. Lessons Learned and Improvements
+
+- **What worked well:** 
+- **What needs improvement:** 
+- **Control Enhancements Required:** 
+- **Training / Awareness Actions:** 
+
+## 9. Post-Incident Tasks
+
+| Task | Owner | Due Date | Status |
+| --- | --- | --- | --- |
+|  |  |  |  |
+|  |  |  |  |
+
+## 10. Approvals
+
+| Name | Role | Approval / Sign-off | Date |
+| --- | --- | --- | --- |
+|  | Incident Commander |  |  |
+|  | Chief Information Security Officer |  |  |
+|  | Risk and Compliance Committee Chair |  |  |
+
+> **Reminder:** Update the risk register, CAPA log, and relevant security metrics with outcomes from this incident.


### PR DESCRIPTION
## Summary
- create a dedicated `templates/` directory with DPIA, RoPA, asset register, risk assessment, NDA, contract, and security incident forms
- document availability of the new templates in the repository README and policy index
- cross-reference the new fillable NDA form from the existing legal NDA guidance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb09ce20b48324bf439117d276fed0