### PR TITLE
Add Zenguard policy vs. repo coverage comparison

### DIFF
--- a/policy-comparison-zenguard-vs-repo.md
+++ b/policy-comparison-zenguard-vs-repo.md
@@ -1,0 +1,47 @@
+# Zenguard Cyber Security Policy vs Cyber Ask Documentation (Repo) Coverage
+
+This table compares the **user-provided Zenguard Cyber Security Policy** against the current Cyber Ask documentation repository to highlight where each set of documents covers (or does not cover) key security domains.
+
+| Area / Control Domain | Zenguard Policy Coverage | Repo Coverage | Notes / Gaps (Repo file references) |
+| --- | --- | --- | --- |
+| Governance, scope, objectives | Yes | Yes | Repo has overarching Information Security Policy with governance model and objectives. (policies/information-security/information-security-policy.md) |
+| Legal / regulatory compliance | Yes (explicit UK acts listed) | Yes | Repo includes Regulatory & Legal Compliance and GDPR/UK DPA policies. (policies/policy-index.md) |
+| Personnel security (contracts, onboarding/offboarding, training) | Yes | Yes | Repo has onboarding/offboarding, training & awareness, code of conduct. (policies/policy-index.md) |
+| Access management (least privilege, admin access, account control) | Yes | Yes | Access Control Policy covers provisioning, reviews, privileged access, and password management. (policies/cyber-security/access-control-policy.md) |
+| Password / authentication standards | Yes (explicit complexity rules) | Yes | Repo has Password & Authentication and MFA policies. (policies/policy-index.md) |
+| Physical security and environmental controls | Yes | Yes | Repo has Physical Security and Environmental Security policies. (policies/policy-index.md) |
+| Asset management and inventory | Yes (asset registers) | Yes | Asset Management Policy covers inventory and lifecycle. (policies/policy-index.md) |
+| Information classification and handling | Yes | Yes | Repo has Data Classification & Handling policy. (policies/policy-index.md) |
+| Removable media controls | Yes (explicit prohibition + monitoring) | Partial | Repo has Media Handling & Equipment Disposal policy but does not explicitly ban removable media. (policies/information-security/media-handling-and-equipment-disposal-policy.md) |
+| BYOD / personal devices | Yes (eligibility + MDM controls) | Partial | Repo has a BYOD policy, but it is high-level without device eligibility or enforcement details. (policies/information-security/bring-your-own-device-byod-policy.md) |
+| Mobile, remote, and home working | Yes (trusted networks, handling data) | Yes | Repo has Remote and Home Working policy. (policies/cyber-security/remote-and-home-working-policy.md) |
+| Social media / external communications | Yes | Yes | Repo has Social Media and External Communications policy. (policies/policy-index.md) |
+| Network perimeter and firewall management | Yes | Yes | Repo has Firewall and Network Security policy. (policies/policy-index.md) |
+| Change management / system change control | Yes | Yes | Repo has Change Management policy. (policies/policy-index.md) |
+| Software management / patching cadence | Yes (patch within 7 days) | Yes | Repo has Patch & Vulnerability Management and End-of-Life Software policies. (policies/policy-index.md) |
+| Local data storage & backups | Yes | Yes | Repo has Backup and Data Retention policy. (policies/policy-index.md) |
+| Cloud services / supplier assurance | Yes (explicit cloud supplier requirements) | Yes | Repo has Cloud Security, Cloud Service Provider Assessment, and Supplier Security policies. (policies/policy-index.md) |
+| Malware protection | Yes | Yes | Repo has Endpoint Security and Malware Protection policy. (policies/policy-index.md) |
+| Vulnerability scanning | Yes (annual external + weekly internal) | Yes | Repo has Patch & Vulnerability Management and Vulnerability Management policies. (policies/policy-index.md) |
+| Incident response | Yes | Yes | Repo has Incident Response Policy and Plan. (policies/policy-index.md) |
+| Business continuity & disaster recovery | Yes | Yes | Repo has Business Continuity Plan and Disaster Recovery Policy. (policies/policy-index.md) |
+| Security reporting / metrics | Yes (DPO reporting) | Yes | Repo has Security Metrics and Reporting policy. (policies/policy-index.md) |
+| Data loss prevention (DLP) | No | Yes | Repo includes a Data Loss Prevention policy. (policies/policy-index.md) |
+| Encryption / cryptography management | No | Yes | Repo includes Encryption and Cryptography/Key Management policies. (policies/policy-index.md) |
+| Secure configuration / hardening | No | Yes | Repo includes Secure Configuration policy. (policies/policy-index.md) |
+| Logging & monitoring | No | Yes | Repo includes Logging and Monitoring policy. (policies/policy-index.md) |
+| AI & emerging tech security | No | Yes | Repo includes AI and Emerging Technology Security policy. (policies/policy-index.md) |
+| Software development security | No | Yes | Repo includes Software Development Security policy. (policies/policy-index.md) |
+| Zero trust architecture | No | Yes | Repo includes Zero Trust Security policy. (policies/policy-index.md) |
+| API / web application security | No | Yes | Repo includes API Security and Web Application Security policies. (policies/policy-index.md) |
+| OT/ICS security | No | Yes | Repo includes OT/ICS Security policy. (policies/policy-index.md) |
+| Internal audit & compliance assurance | No | Yes | Repo includes Internal Audit and Document Control policies. (policies/policy-index.md) |
+| Risk management / SoA / treatment plans | No | Yes | Repo includes Risk Management Policy, Risk Treatment Plan, and Statement of Applicability. (policies/policy-index.md) |
+| Supply chain / outsourcing governance | No | Yes | Repo includes Supplier Security, Supply Chain Continuity, and Outsourcing policies. (policies/policy-index.md) |
+| Threat intelligence | No | Yes | Repo includes Monitoring and Threat Intelligence policy. (policies/policy-index.md) |
+| Vulnerability disclosure process | No | Yes | Repo includes Vulnerability Disclosure and Reporting policy. (policies/policy-index.md) |
+| Passwordless authentication | No | Yes | Repo includes Passwordless Authentication policy. (policies/policy-index.md) |
+| Wireless security | No | Yes | Repo includes Wireless Security policy. (policies/policy-index.md) |
+| Remote administration controls | No | Yes | Repo includes Remote Administration policy. (policies/policy-index.md) |
+| Data integrity & quality | No | Yes | Repo includes Data Integrity and Quality policy. (policies/policy-index.md) |
+| Records management & archiving | No | Yes | Repo includes Records Management and Archiving policy. (policies/policy-index.md) |


### PR DESCRIPTION
### Motivation
- Provide a concise mapping between the user-supplied Zenguard Cyber Security Policy and the existing Cyber Ask documentation to quickly identify alignment and coverage gaps.

### Description
- Add `policy-comparison-zenguard-vs-repo.md`, a markdown table that maps Zenguard policy domains to repo policies and highlights partial or missing coverage (notably removable media controls and BYOD enforcement details).

### Testing
- No automated tests were run because this is a documentation-only change; the new file `policy-comparison-zenguard-vs-repo.md` was added to the repository for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698099c1b3f48324b4af01ef05fbe359)